### PR TITLE
Publish version tag + docker image tidy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: octoeverywhere/octoeverywhere
+          tags: |
+            # set latest tag
+            type=raw,value=latest
+            # set versioned tag
+            type=semver,pattern={{version}}
+
 
       - name: Build and push Docker image
         id: push
@@ -48,7 +54,7 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           file: ./Dockerfile
           push: true
-          tags: octoeverywhere/octoeverywhere:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # This isn't working, so it's disabled for now.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Start with the lastest ubuntu, for a solid base,
+# Start with the lastest alpine, for a solid base,
 # since we need some advance binaries for things like pillow and ffmpeg.
 FROM alpine:3.20.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@
 FROM alpine:3.20.0
 
 # We will base ourselves in root, becuase why not.
-WORKDIR /app
+WORKDIR /root
 
 # Define some user vars we will use for the image.
 # These are read in the docker_octoeverywhere module, so they must not change!
+ENV USER=root
 ENV REPO_DIR=/app/octoeverywhere
 ENV VENV_DIR=/app/octoeverywhere-env
 # This is a special dir that the user MUST mount to the host, so that the data is persisted.
@@ -15,7 +16,7 @@ ENV DATA_DIR=/data/
 
 # Install the required packages.
 # Any packages here should be mirrored in the install script - and any optaionl pillow packages done inline.
-RUN apk add curl ffmpeg jq python3 py3-pip py3-virtualenv jpeg-dev libjpeg-turbo-dev zlib-dev py3-pillow
+RUN apk add --no-cache curl ffmpeg jq python3 py3-pip py3-virtualenv jpeg-dev libjpeg-turbo-dev zlib-dev py3-pillow
 
 #
 # We decided to not run the installer, since the point of the installer is to setup the env, build the launch args, and setup the serivce.
@@ -32,4 +33,4 @@ RUN ${VENV_DIR}/bin/pip3 install --require-virtualenv --no-cache-dir -q -r ${REP
 # For docker, we use our docker_octoeverywhere host to handle the runtime setup and launch of the serivce.
 WORKDIR ${REPO_DIR}
 # Use the full path to the venv, we msut use this [] notation for our ctlc handler to work in the contianer
-ENTRYPOINT ["/app/octoeverywhere-env/bin/python", "-m", "docker_octoeverywhere"]
+ENTRYPOINT ["/root/octoeverywhere-env/bin/python", "-m", "docker_octoeverywhere"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,21 @@
 # Start with the lastest ubuntu, for a solid base,
 # since we need some advance binaries for things like pillow and ffmpeg.
-FROM ubuntu:latest
+FROM alpine:3.20.0
 
 # We will base ourselves in root, becuase why not.
-WORKDIR /root
+WORKDIR /app
 
 # Define some user vars we will use for the image.
 # These are read in the docker_octoeverywhere module, so they must not change!
-ENV USER=root
-ENV REPO_DIR=/root/octoeverywhere
-ENV VENV_DIR=/root/octoeverywhere-env
+ENV REPO_DIR=/app/octoeverywhere
+ENV VENV_DIR=/app/octoeverywhere-env
 # This is a special dir that the user MUST mount to the host, so that the data is persisted.
 # If this is not mounted, the printer will need to be re-linked everytime the container is remade.
 ENV DATA_DIR=/data/
 
 # Install the required packages.
 # Any packages here should be mirrored in the install script - and any optaionl pillow packages done inline.
-RUN apt update
-RUN apt install -y curl ffmpeg jq python3 python3-pip python3-venv virtualenv libjpeg-dev zlib1g-dev python3-pil python3-pillow
+RUN apk add curl ffmpeg jq python3 py3-pip py3-virtualenv jpeg-dev libjpeg-turbo-dev zlib-dev py3-pillow
 
 #
 # We decided to not run the installer, since the point of the installer is to setup the env, build the launch args, and setup the serivce.
@@ -34,4 +32,4 @@ RUN ${VENV_DIR}/bin/pip3 install --require-virtualenv --no-cache-dir -q -r ${REP
 # For docker, we use our docker_octoeverywhere host to handle the runtime setup and launch of the serivce.
 WORKDIR ${REPO_DIR}
 # Use the full path to the venv, we msut use this [] notation for our ctlc handler to work in the contianer
-ENTRYPOINT ["/root/octoeverywhere-env/bin/python", "-m", "docker_octoeverywhere"]
+ENTRYPOINT ["/app/octoeverywhere-env/bin/python", "-m", "docker_octoeverywhere"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /root
 # Define some user vars we will use for the image.
 # These are read in the docker_octoeverywhere module, so they must not change!
 ENV USER=root
-ENV REPO_DIR=/app/octoeverywhere
-ENV VENV_DIR=/app/octoeverywhere-env
+ENV REPO_DIR=/root/octoeverywhere
+ENV VENV_DIR=/root/octoeverywhere-env
 # This is a special dir that the user MUST mount to the host, so that the data is persisted.
 # If this is not mounted, the printer will need to be re-linked everytime the container is remade.
 ENV DATA_DIR=/data/


### PR DESCRIPTION
Hi

I changed the docker image from Ubuntu to Alpine, it should speed up docker build times but is also way smaller in size:-
`263MB` vs `1.25GB`
```
REPOSITORY                      TAG       IMAGE ID       CREATED          SIZE
bambu-connect                   latest    08ceb71deba8   58 seconds ago   263MB
octoeverywhere/octoeverywhere   latest    233d8120767f   9 days ago       1.25GB
```

I also added versioning to the docker tags so there isn't just `latest`. This is because I use Kubernetes which means the images are cached with `latest`... and if there's an update nothing will happen, it'll just keep running latest (unless it switches to a brand new node that has never pulled the image or I set to always pull).
So example use would be `octoeverywhere/octoeverywhere:3.3.5`

Any questions lemme know :)
