### PR TITLE
Fix LAN_ONLY_MODE failing to handle undefined env var

### DIFF
--- a/docker_octoeverywhere/__main__.py
+++ b/docker_octoeverywhere/__main__.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
         # The work around was to connect to the Bambu Cloud instead of directly to the printer.
         # The biggest downside of this is that we need to get the user's email address and password for Bambu Cloud.
         # BUT the user can also do the LAN only mode, if they want to.
-        isLanOnlyMode = os.environ.get("LAN_ONLY_MODE", False)
+        isLanOnlyMode = bool(os.environ.get("LAN_ONLY_MODE", "").lower() in ("true", "1", "yes"))
         isAccessCodeRequired = True
         if isLanOnlyMode:
             # In LAN only mode we only need the Serial number and access code.


### PR DESCRIPTION
## Problem

As a user who is attempting to setup octoeverywhere with a new bambu printer, using the octoprint cloud (not lan only mode).
I find that the docker container fails to start and prints out the following error. 

<img width="1139" alt="Screenshot 2024-06-27 at 4 54 17 PM" src="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/assets/242382/8838b201-5aec-4fec-a1d5-39c1ad314899">

Here are the environment variables that I'm using:

(Note that `LAN_ONLY_MODE` is not defined)

<img width="559" alt="Screenshot 2024-06-27 at 5 04 52 PM" src="https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/assets/242382/736d058b-0f5c-4f1a-a4f8-0f8dba85345a">

## Changes

This changes the `isLanOnlyMode` to handle the edge cases where a user does one of the following
1. Omits `LAN_ONLY_MODE`
2. Mistakenly uses a string instead of a boolean ( `LAN_ONLY_MODE="False"` instead of `LAN_ONLY_MODE=False`)


## Additional thoughts

It seems surprising that I'm the first person to run into this, please let me know if I'm overlooking something simple

## Testing

TODO:
- [ ] Build docker container and test