### PR TITLE
Remove log of all env variables

### DIFF
--- a/docker_octoeverywhere/__main__.py
+++ b/docker_octoeverywhere/__main__.py
@@ -59,7 +59,6 @@ if __name__ == '__main__':
 
     try:
         # First, read the required env vars that are set in the dockerfile.
-        logger.info(f"Env Vars: {os.environ}")
         virtualEnvPath = EnsureIsPath(os.environ.get("VENV_DIR", None))
         repoRootPath = EnsureIsPath(os.environ.get("REPO_DIR", None))
         dataPath = EnsureIsPath(os.environ.get("DATA_DIR", None))


### PR DESCRIPTION
I suggest to remove the log of all environment variables. In managed environements those might contain sensitive information, which are not meant to be shared with everyone that has access to the logs. Its a good habit for an app only to show information regarding the app specific variables.
