### PR TITLE
Added tzdata to allow time zone to be set properly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,13 @@ ENV DATA_DIR=/data/
 # GCC, python3-dev, and musl-dev are required for pillow, and jpeg-dev and zlib-dev are required for jpeg support.
 RUN apk add --no-cache curl ffmpeg jq python3 python3-dev gcc musl-dev py3-pip py3-virtualenv jpeg-dev libjpeg-turbo-dev zlib-dev py3-pillow libffi-dev
 
+# Timezone setup steps
+# These steps are necessary to add timezone support to the container and allow for setting the timezone
+# This allows the log files to show the correct local time
+RUN apk add --no-cache tzdata
+ENV TZ=Etc/GMT
+RUN cp /usr/share/zoneinfo/Etc/GMT /etc/localtime
+
 #
 # We decided to not run the installer, since the point of the installer is to setup the env, build the launch args, and setup the service.
 # Instead, we will manually run the smaller subset of commands that are required to get the env setup in docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - SERIAL_NUMBER=XXXXXXXXXXXXXXX
         # Find using the printer's display or use https://octoeverywhere.com/s/bambu-ip
       - PRINTER_IP=XXX.XXX.XXX.XXX
+        # Set timezone to proper timezone for logs using standard timezones:
+        # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+      - TZ=America/NewYork
 
       # Optionally: If you want to connect via the Bambu Cloud, you can specify the following environment variables.
       # By default the plugin will use the local connection mode, which is preferred.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - PRINTER_IP=XXX.XXX.XXX.XXX
         # Set timezone to proper timezone for logs using standard timezones:
         # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
-      - TZ=America/NewYork
+      - TZ=America/New_York
 
       # Optionally: If you want to connect via the Bambu Cloud, you can specify the following environment variables.
       # By default the plugin will use the local connection mode, which is preferred.


### PR DESCRIPTION
Added files to Container to allow for the time zone to be properly set in the compose file. These changes will allow the log files to show proper local time as long as the time zone is set properly in the compose file. It was defaulted to GMT, and ignoring it won't cause any issues, your logs will just be in GMT.

This PR Fixes #89 