### PR TITLE
Fixes issue with assigning variable after thread has already began

### DIFF
--- a/octoeverywhere/WebStream/octowebstreamhttphelper.py
+++ b/octoeverywhere/WebStream/octowebstreamhttphelper.py
@@ -1187,8 +1187,8 @@ class OctoWebStreamHttpHelper:
         if self.UnknownBodyChunkReadContext is None:
             context = UnknownBodyChunkReadContext(httpResult)
             context.Thread = threading.Thread(target=self.doUnknownBodyChunkReadThread)
-            context.Thread.start()
             self.UnknownBodyChunkReadContext = context
+            context.Thread.start()
 
         try:
             startSec = time.time()


### PR DESCRIPTION
My server is returning the following headers

```
Content-Type: text/html
Transfer-Encoding: chunked
Connection: keep-alive
```

Which was causing the below code to throw

```
2025-02-10 23:31:01,710 - octoprint.plugins.octoeverywhere - ERROR - Web Stream http [50]  exception thrown in doUnknownBodyChunkReadThread; AttributeError Exception: 'NoneType' object has no attribute 'HttpResult'; Traceback (most recent call last):
  File "OctoPrint/lib/python3.11/site-packages/octoeverywhere/WebStream/octowebstreamhttphelper.py", line 1114, in doUnknownBodyChunkReadThread
    # Get the Request response object.
               ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'HttpResult'
```

This is because the thread was starting, and the variable was currently null since `self.UnknownBodyChunkReadContext = context` was not assigned yet.

Swapping the lines locally fixed the issue I was having.
