### PR TITLE
Fix type hint for _ScanForMoonrakerInstances method to use List instead of list

### DIFF
--- a/py_installer/NetworkConnectors/MoonrakerConnector.py
+++ b/py_installer/NetworkConnectors/MoonrakerConnector.py
@@ -2,7 +2,7 @@ import json
 import socket
 import threading
 import ipaddress
-from typing import Tuple
+from typing import Tuple, List
 
 from octoeverywhere.websocketimpl import Client
 
@@ -295,7 +295,7 @@ class MoonrakerConnector:
 
     # Scans the subnet for Moonraker instances.
     # Returns a list of IPs where moonraker was found.
-    def _ScanForMoonrakerInstances(self) -> list[MoonrakerScanResult]:
+    def _ScanForMoonrakerInstances(self) -> List[MoonrakerScanResult]:
         results = []
         try:
             localIp = self._TryToGetLocalIp()


### PR DESCRIPTION
# Fix Python 3.7 Type Annotation Compatibility in Moonraker Connector

## Description
This PR fixes a compatibility issue with Python 3.7 installations where type annotations in the MoonrakerConnector were using Python 3.9+ syntax. The error manifested as:

```python
TypeError: 'type' object is not subscriptable
```

## Changes
- Updated type hints in `py_installer/NetworkConnectors/MoonrakerConnector.py` to use Python 3.7 compatible syntax
- Changed `list[MoonrakerScanResult]` to `List[MoonrakerScanResult]`
- Added proper imports from `typing` module

## Why
Many 3D printer installations still run Python 3.7, particularly on embedded systems and older OS distributions. This change ensures compatibility without requiring users to upgrade their Python version.

Python 3.9 introduced the simpler built-in syntax as "syntactic sugar", but it didn't deprecate or remove the typing module approach. Both syntaxes work in Python 3.9+, making the Python 3.7 syntax backward and forward compatible.

This is why using the typing.List syntax is often preferred in libraries that need to support multiple Python versions - it works everywhere from Python 3.7 onwards. The change we made ensures maximum compatibility without any downsides for users running newer Python versions.

## Testing
- Verified the code runs without type annotation errors on Python 3.7
- Confirmed functionality remains the same
- Tested on a system running Python 3.7
- Confirmed after fix was implemented I was able to install via `install.sh` on my Neptune 4 Max
![CleanShot 2025-04-12 at 21 42 56@2x](https://github.com/user-attachments/assets/38c11b65-129a-435d-9bc5-9d159520dd1b)


## Related Issues
Fixes #103 