### PR TITLE
defect: allow moonraker config to be a link

### DIFF
--- a/py_installer/Discovery.py
+++ b/py_installer/Discovery.py
@@ -184,7 +184,7 @@ class Discovery:
         # The service file should be something like this "/etc/init.d/S56moonraker_service" or "/etc/init.d/moonraker" on the K2
         for fileOrDirName in os.listdir(Paths.CrealityOsServiceFilePath):
             fullFileOrDirPath = os.path.join(Paths.CrealityOsServiceFilePath, fileOrDirName)
-            if os.path.isfile(fullFileOrDirPath) and os.path.islink(fullFileOrDirPath) is False:
+            if os.path.isfile(fullFileOrDirPath):
                 if "moonraker" in fileOrDirName.lower():
                     Logger.Debug(f"Found service file: {fullFileOrDirPath}")
                     moonrakerServiceFileName = fileOrDirName


### PR DESCRIPTION
K2 Plus improvements [creates soft links](https://github.com/jamincollins/k2-improvements/blob/d9fef11151959649084dbf546efd9db11f716efb/features/moonraker/install.sh#L95) for the config files when setting up moonraker. The installation script fails to identify existence of moonraker on the K2 Plus.