### PR TITLE
Fix log text for outgoing Bambu messages

### DIFF
--- a/bambu_octoeverywhere/bambuclient.py
+++ b/bambu_octoeverywhere/bambuclient.py
@@ -405,7 +405,7 @@ class BambuClient:
         try:
             # Print for debugging if desired.
             if self.Logger.isEnabledFor(logging.DEBUG):
-                self.Logger.debug("Incoming Bambu Message:\r\n"+json.dumps(msg, indent=3))
+                self.Logger.debug("Outgoing Bambu Message:\r\n" + json.dumps(msg, indent=3))
 
             # Ensure we are connected.
             if self.Client is None or not self.Client.is_connected():


### PR DESCRIPTION
## Summary
- correct a debug log message

## Testing
- `ruff check .`
- `pyright` *(fails: Import "paho.mqtt.client" could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683f54f00d5083339cdc53a404043c9f