### PR TITLE
Fix typos and small code cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The OctoEverywhere Docker Container plugin can be use for:
 - [OctoEverywhere Elegoo Connect](https://octoeverywhere.com/elegoo-centauri?source=github_readme_docker) - OctoEverywhere for Elegoo Centauri & Centauri Carbon 3D printers.
 - [OctoEverywhere Klipper Companion](https://octoeverywhere.com/?source=github_readme_docker) - OctoEverywhere for Klipper 3D printers.
 
-Our Docker container can be ran on Windows, Linux, Mac, or just about anywhere.
+Our Docker container can be run on Windows, Linux, Mac, or just about anywhere.
 
 [Follow our step-by-step setup guide to get started.](https://octoeverywhere.com/getstarted?source=github_readme_install_docker_guide)
 

--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,7 @@ OE_ENV="${HOME}/octoeverywhere-env"
 # The python requirements are for the installer and plugin
 # The virtualenv is for our virtual package env we create
 # The curl requirement is for some things in this bootstrap script.
-# python3-venv is required for teh virtualenv command to fully work.
+# python3-venv is required for the virtualenv command to fully work.
 # This must stay in sync with the dockerfile package installs
 PKGLIST="python3 python3-pip virtualenv python3-venv curl"
 # For the Creality OS, we only need to install these.

--- a/linux_host/networksearch.py
+++ b/linux_host/networksearch.py
@@ -453,7 +453,7 @@ class NetworkSearch:
                             with threadLock:
                                 # If successful, add the IP to the found list.
                                 if result.Success():
-                                    # Enure we haven't already found the requested number of IPs,
+                                    # Ensure we haven't already found the requested number of IPs,
                                     # because then the result list might have already been returned
                                     # and we don't want to mess with it.
                                     if hasFoundRequestedNumberOfIps[0] is True:

--- a/moonraker_octoeverywhere/uiinjector.py
+++ b/moonraker_octoeverywhere/uiinjector.py
@@ -126,8 +126,7 @@ class UiInjector():
                 if not data:
                     break
                 sha1.update(data)
-        #pylint: disable=consider-using-f-string
-        self.StaticFileHash = "{0}".format(sha1.hexdigest())
+        self.StaticFileHash = f"{sha1.hexdigest()}"
         self.StaticFileHash = self.StaticFileHash[:10]
         self.Logger.debug("Static UI Files Hash: "+self.StaticFileHash)
 

--- a/octoeverywhere/buffer.py
+++ b/octoeverywhere/buffer.py
@@ -160,29 +160,26 @@ class Buffer():
             return iter([])
 
 
-    # Allow the buffer to be sliced.
-    # TODO - Once we move past PY 3.7, we can use SupportsIndex for the start and end.
-    def __getslice__(self, start:int, end:int) -> ByteLikeOrMemoryView:
-        if self._bytes is not None:
-            return self._bytes[start:end]
-        elif self._bytearray is not None:
-            return self._bytearray[start:end]
-        elif self._memoryview is not None:
-            return self._memoryview[start:end]
+    # Allow the buffer to be indexed or sliced.
+    def __getitem__(self, key:Union[int, slice]) -> Union[int, ByteLikeOrMemoryView]:
+        if isinstance(key, slice):
+            if self._bytes is not None:
+                return self._bytes[key]
+            elif self._bytearray is not None:
+                return self._bytearray[key]
+            elif self._memoryview is not None:
+                return self._memoryview[key]
+            else:
+                raise ValueError("Buffer is empty")
         else:
-            raise ValueError("Buffer is empty")
-
-
-    # Allow the buffer to be indexed.
-    def __getitem__(self, key:int) -> int:
-        if self._bytes is not None:
-            return self._bytes[key]
-        elif self._bytearray is not None:
-            return self._bytearray[key]
-        elif self._memoryview is not None:
-            return self._memoryview[key]
-        else:
-            raise ValueError("Buffer is empty")
+            if self._bytes is not None:
+                return self._bytes[key]
+            elif self._bytearray is not None:
+                return self._bytearray[key]
+            elif self._memoryview is not None:
+                return self._memoryview[key]
+            else:
+                raise ValueError("Buffer is empty")
 
 
     # Allow the buffer to be set.


### PR DESCRIPTION
## Summary
- tweak README grammar
- fix a typo in the install script comment
- correct a comment typo in the network search helper
- use an f-string for the static hash generation
- modernize Buffer indexing to support slicing

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686947cbfeec83339c3a96efb4945a65