### PR TITLE
Fix various small issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -144,7 +144,7 @@
         "moonrakerapirouter",
         "moonrakerclient",
         "moonrakercommandhandler",
-        "moonrakercredentailmanager",
+        "moonrakercredentialmanager",
         "moonrakerdatabase",
         "moonrakerhost",
         "moonrakerwebcamhelper",

--- a/moonraker_octoeverywhere/moonrakerclient.py
+++ b/moonraker_octoeverywhere/moonrakerclient.py
@@ -22,7 +22,7 @@ from octoeverywhere.interfaces import IWebSocketClient, IPrinterStateReporter, W
 from linux_host.config import Config
 
 from .filemetadatacache import FileMetadataCache
-from .moonrakercredentailmanager import MoonrakerCredentialManager
+from .moonrakercredentialmanager import MoonrakerCredentialManager
 from .interfaces import IMoonrakerConnectionStatusHandler
 from .jsonrpcresponse import JsonRpcResponse
 from .interfaces import IMoonrakerClient

--- a/moonraker_octoeverywhere/moonrakercredentialmanager.py
+++ b/moonraker_octoeverywhere/moonrakercredentialmanager.py
@@ -235,6 +235,8 @@ class MoonrakerCredentialManager:
 
             # Read one, add it to the buffer, and see if we are done.
             data = sock.recv(1)
+            if not data:
+                return None
             if data[0] == 3: # This is EXT aka End of text. It separates the json messages.
                 return message.decode(encoding="utf-8")
             message += data

--- a/moonraker_octoeverywhere/moonrakerhost.py
+++ b/moonraker_octoeverywhere/moonrakerhost.py
@@ -35,7 +35,7 @@ from .moonrakerwebcamhelper import MoonrakerWebcamHelper
 from .moonrakerdatabase import MoonrakerDatabase
 from .webrequestresponsehandler import MoonrakerWebRequestResponseHandler
 from .moonrakerapirouter import MoonrakerApiRouter
-from .moonrakercredentailmanager import MoonrakerCredentialManager
+from .moonrakercredentialmanager import MoonrakerCredentialManager
 from .filemetadatacache import FileMetadataCache
 from .uiinjector import UiInjector
 from .interfaces import IMoonrakerConnectionStatusHandler

--- a/octoeverywhere/localip.py
+++ b/octoeverywhere/localip.py
@@ -22,14 +22,12 @@ class LocalIpHelper:
 
         # Find the local IP. Works on Windows and Linux. Always gets the correct routable IP.
         # https://stackoverflow.com/a/28950776
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         ip = ""
         try:
             # doesn't even have to be reachable
-            s.connect(('1.1.1.1', 1))
-            ip = s.getsockname()[0]
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect(("1.1.1.1", 1))
+                ip = s.getsockname()[0]
         except Exception:
             pass
-        finally:
-            s.close()
         return str(ip)

--- a/octoeverywhere/printinfo.py
+++ b/octoeverywhere/printinfo.py
@@ -111,7 +111,7 @@ class PrintInfo:
     def GetEstFilamentWeightUsageMg(self) -> int:
         return self.Data.get(PrintInfo.c_EstFilamentWeightMg, 0)
     def SetEstFilamentWeightUsageMg(self, estG:int) -> None:
-        if self.GetEstFilamentUsageMm() != estG:
+        if self.GetEstFilamentWeightUsageMg() != estG:
             self.Data[PrintInfo.c_EstFilamentWeightMg] = estG
             self.Save()
 
@@ -142,7 +142,7 @@ class PrintInfo:
                 json.dump(self.Data, f)
             return True
         except Exception as e:
-            self.Logger.error(f"Failed to write print context from file. {e}")
+            self.Logger.error(f"Failed to write print context to file. {e}")
         return False
 
 


### PR DESCRIPTION
## Summary
- fix typo in moonraker credential manager file name
- guard socket reading in credential manager against empty reads
- correct estimated filament weight setter and typo in log
- use context manager when querying local IP

## Testing
- `ruff check`
- `pylint moonraker_octoeverywhere/moonrakercredentialmanager.py octoeverywhere/localip.py octoeverywhere/printinfo.py`

------
https://chatgpt.com/codex/tasks/task_e_686947ae936c83339a2a624087fb1f79