### PR TITLE
Update KlipperBootstrap.py with the right default Moonraker port

### DIFF
--- a/docker_octoeverywhere/KlipperBootstrap.py
+++ b/docker_octoeverywhere/KlipperBootstrap.py
@@ -45,7 +45,7 @@ class KlipperBootstrap:
         printerPort = config.GetStr(Config.SectionCompanion, Config.CompanionKeyPort, None)
         if printerPort is None:
             logger.info("Setting The Default Moonraker Port: 7125")
-            config.SetStr(Config.SectionCompanion, Config.CompanionKeyPort, "7215")
+            config.SetStr(Config.SectionCompanion, Config.CompanionKeyPort, "7125")
         else:
             logger.info(f"Target Moonraker Port: {printerPort}")
 


### PR DESCRIPTION
There was a typo in the default Moonraker port number so it was not working until I figured I could setup the port via MOONRAKER_PORT env. 
Anyway, it is a small fix, I hope you can approve the PR. Thanks!