### PR TITLE
Fixed default port for Centauri Carbon 2

### DIFF
--- a/docker_octoeverywhere/ElegooCc2Bootstrap.py
+++ b/docker_octoeverywhere/ElegooCc2Bootstrap.py
@@ -11,8 +11,11 @@ class ElegooCc2Bootstrap:
     @staticmethod
     def Bootstrap(logger:logging.Logger, config:Config) -> None:
 
-        # Set the printer protocol to Elegoo CC2, so the rest of the code knows which printer we're targeting and can adjust behavior accordingly.
+        # These are constants that are always used for Elegoo CC2 connect.
+        # The CC2 runs an MQTT broker on port 1883
+        # Always set these to ensure they override any other settings from other companion modes.
         config.SetStr(Config.SectionElegoo, Config.ElegooPrinterProtocol, Config.ElegooPrinterProtocolCc2)
+        config.SetStr(Config.SectionCompanion, Config.CompanionKeyPort, "1883")
 
         # The printer IP is always required.
         printerIp = os.environ.get("PRINTER_IP", None)


### PR DESCRIPTION
When trying to configure the docker container for my CC2, I couldn't make it connect. In container logs,  it was flooding with connection attempts to web UI port which is only valid for CC1 and is inaccessible for CC2. I fixed that by manually editing the config file which is generated based on environment vars, but that's an obvious bug and needs a proper fix.


<details>
<summary>Container logs</summary>

```
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:28,915 - INFO - Trying to connect to Elegoo CC2 printer at 192.168.10.22:3030...
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:28,916 - INFO - MqttMux connecting to 192.168.10.22:3030 (transport=tcp)
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:28,918 - WARNING - MqttMux connect attempt failed: [Errno 111] Connection refused
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:28,918 - INFO - MqttMux sleeping 20.0s before reconnect
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:48,919 - INFO - Trying to connect to Elegoo CC2 printer at 192.168.10.22:3030...
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:48,919 - INFO - MqttMux connecting to 192.168.10.22:3030 (transport=tcp)
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:48,921 - WARNING - MqttMux connect attempt failed: [Errno 111] Connection refused
octoeverywhere-elegoo-connect-1  | 2026-06-21 19:01:48,921 - INFO - MqttMux sleeping 40.0s before reconnect
```
</details>
