### PR TITLE
Webcam URL query param fixes

### DIFF
--- a/octoeverywhere/Webcam/quickcam.py
+++ b/octoeverywhere/Webcam/quickcam.py
@@ -50,6 +50,29 @@ class QuickCamManager:
     # Used on some platforms when we know the stream is jmpeg, we add this to the URL so we can identify it easily.
     c_JMpegExtension = ".mjpg"
 
+    # The only query params we keep when normalizing a QuickCam URL. (see _NormalizeQuickCamUrl)
+    # Anything not on this list is dropped, since it's assumed to be cache busting noise, which would prevent
+    # streams from being shared and would spin up a new QuickCam instance (and capture thread) per request.
+    # Note the normalized URL is also the URL we actually connect to, so anything the webcam server needs
+    # to serve the stream - auth included - must be on this list!
+    # These values must all stay lower case, the compare is done against a lowercased param name.
+    c_AllowedGetParams = frozenset([
+        # Endpoint and stream selection. These are part of the URL contract, dropping them changes what's returned.
+        "action",                                                   # mjpg-streamer, ustreamer, camera-streamer (action=stream|snapshot)
+        "cmd",                                                      # Reolink (cmd=Snap|Video)
+        "src",                                                      # go2rtc
+        "channel", "subtype", "subject", "stream", "cam", "camera", # Dahua, Amcrest, Hikvision, OpenIPC, thingino, go2rtc
+        # Auth. Some setups put creds or a signed token in the query string, stripping them results in a 401.
+        "token", "access_token", "accesstoken", "auth", "authtoken",
+        "apikey", "api_key", "key",
+        "user", "username", "usr", "password", "passwd", "pwd",
+        "sig", "signature", "session", "sessionid",
+        # Stream quality and format, which are meaningful to the server and safe to keep.
+        c_FpsGetParam,
+        "quality", "resolution", "width", "height", "w", "h",
+        "rotate", "bitrate", "br", "codec", "format", "mode",
+    ])
+
 
     _Instance:"QuickCamManager" = None #pyright: ignore[reportAssignmentType]
 
@@ -149,24 +172,30 @@ class QuickCamManager:
             return qc
 
 
+    # Normalizes a webcam URL by stripping any query param that's not on the c_AllowedGetParams list.
+    # This is used to key the QuickCamMap, so cache busting params (which are unique per request) don't
+    # prevent streams from being shared. But it's also the URL we connect to, so any param the webcam
+    # server actually needs - like an auth token - must be on the allow list or the request will fail.
     def _NormalizeQuickCamUrl(self, url:str) -> str:
-        # Strip cache-busting query params while preserving action=stream style URLs.
-        if url.find("?") == -1:
+        # Most URLs have no query string at all, so we can skip all of the parsing work and return them untouched.
+        if "?" not in url:
             return url
 
         parts = urlsplit(url)
-        actionParams:List[Tuple[str, str]] = []
+        allowedParams:List[Tuple[str, str]] = []
+        strippedNames:List[str] = []
         for name, value in parse_qsl(parts.query, keep_blank_values=True):
-            nameLower = name.lower()
             # Important! We need to keep some params around so they don't get lost when trying to control the server!
-            if nameLower == "action" or nameLower == QuickCamManager.c_FpsGetParam:
-                actionParams.append((name, value))
+            if name.lower() in QuickCamManager.c_AllowedGetParams:
+                allowedParams.append((name, value))
             else:
-                self.Logger.debug("Stripping _NormalizeQuickCamUrl query param %s from QuickCam URL for normalization.", name)
+                strippedNames.append(name)
 
+        if len(strippedNames) > 0:
+            self.Logger.debug("_NormalizeQuickCamUrl stripped the query params [%s] from the QuickCam URL for normalization.", ", ".join(strippedNames))
 
-        query = urlencode(actionParams)
-        return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+        # SplitResult is a named tuple, so _replace is the supported way to swap out just the query string.
+        return urlunsplit(parts._replace(query=urlencode(allowedParams)))
 
 
 # This class handles webcam streaming from different streaming endpoints that aren't http.

--- a/tests/test_quickcam_url.py
+++ b/tests/test_quickcam_url.py
@@ -1,0 +1,125 @@
+# ruff: noqa: E402
+import logging
+import unittest
+
+from tests.test_dependency_stubs import InstallTestDependencyStubs
+
+InstallTestDependencyStubs()
+
+from octoeverywhere.Webcam.quickcam import QuickCamManager
+
+
+# QuickCam only calls into the platform helper once a capture thread is running, which these tests never do.
+class FakeWebcamPlatformHelper:
+
+    def OnQuickCamStreamStart(self, url:str) -> None:
+        raise AssertionError("OnQuickCamStreamStart should not be called by these tests.")
+
+
+    def OnQuickCamStreamStall(self, url:str) -> None:
+        raise AssertionError("OnQuickCamStreamStall should not be called by these tests.")
+
+
+    def ShouldQuickCamKeepRunning(self) -> bool:
+        return False
+
+
+class TestQuickCamUrlNormalization(unittest.TestCase):
+
+    def setUp(self) -> None:
+        logger = logging.getLogger("TestQuickCamUrlNormalization")
+        logger.addHandler(logging.NullHandler())
+        self.Manager = QuickCamManager(logger, FakeWebcamPlatformHelper()) #pyright: ignore[reportArgumentType]
+
+
+    def _Normalize(self, url:str) -> str:
+        return self.Manager._NormalizeQuickCamUrl(url) #pylint: disable=protected-access
+
+
+    # This is the bug that caused the webcam to 401 - the auth token was being stripped from the URL we connect to.
+    def test_auth_params_are_kept(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?action=stream&token=abc123"),
+                         "http://192.168.1.5/webcam/?action=stream&token=abc123")
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?action=stream&apikey=abc123"),
+                         "http://192.168.1.5/webcam/?action=stream&apikey=abc123")
+        self.assertEqual(self._Normalize("jmpeg://192.168.1.5/stream?action=stream&token=abc123"),
+                         "jmpeg://192.168.1.5/stream?action=stream&token=abc123")
+        self.assertEqual(self._Normalize("http://192.168.1.5/cgi-bin/api.cgi?cmd=Video&channel=0&user=me&password=secret"),
+                         "http://192.168.1.5/cgi-bin/api.cgi?cmd=Video&channel=0&user=me&password=secret")
+
+
+    # The reason this function exists in the first place - unique params per request would prevent stream sharing.
+    def test_cache_busting_params_are_stripped(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?action=stream&t=1699999999&cachebust=xyz"),
+                         "http://192.168.1.5/webcam/?action=stream")
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?_=1699999999&rand=55&nocache=1&action=snapshot"),
+                         "http://192.168.1.5/webcam/?action=snapshot")
+
+
+    # This is the URL built by WebcamHelper.DetectWebRTCStreamUrlAndTranslate for the Snapmaker U1.
+    def test_fps_param_is_kept(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/stream.mjpg?fps=10"),
+                         "http://192.168.1.5/webcam/stream.mjpg?fps=10")
+
+
+    def test_param_names_are_matched_case_insensitively(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?ACTION=stream&Token=abc123"),
+                         "http://192.168.1.5/webcam/?ACTION=stream&Token=abc123")
+
+
+    def test_urls_without_params_are_untouched(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/"), "http://192.168.1.5/webcam/")
+        self.assertEqual(self._Normalize("rtsp://user:pass@192.168.1.5:554/stream1"), "rtsp://user:pass@192.168.1.5:554/stream1")
+        # An empty query string still hits the parse path, but there's nothing to keep.
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?"), "http://192.168.1.5/webcam/")
+
+
+    def test_blank_values_and_fragments_are_preserved(self) -> None:
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?action=stream&token="),
+                         "http://192.168.1.5/webcam/?action=stream&token=")
+        self.assertEqual(self._Normalize("http://192.168.1.5/webcam/?action=stream&t=123#frag"),
+                         "http://192.168.1.5/webcam/?action=stream#frag")
+
+
+    # Tokens are often base64ish, so they must survive the parse and re-encode round trip.
+    def test_encoded_values_round_trip(self) -> None:
+        # The value decodes to 'a+b/c=' and must be re-encoded so the server sees the same value.
+        normalized = self._Normalize("http://192.168.1.5/webcam/?action=stream&token=a%2Bb%2Fc%3D")
+        self.assertEqual(self._Normalize(normalized), normalized)
+        from urllib.parse import parse_qs, urlsplit #pylint: disable=import-outside-toplevel
+        self.assertEqual(parse_qs(urlsplit(normalized).query)["token"], ["a+b/c="])
+
+
+class TestQuickCamInstanceSharing(unittest.TestCase):
+
+    def setUp(self) -> None:
+        logger = logging.getLogger("TestQuickCamInstanceSharing")
+        logger.addHandler(logging.NullHandler())
+        self.Manager = QuickCamManager(logger, FakeWebcamPlatformHelper()) #pyright: ignore[reportArgumentType]
+
+
+    def _GetOrCreate(self, url:str):
+        return self.Manager._GetOrCreate(url) #pylint: disable=protected-access
+
+
+    def test_cache_busted_urls_share_one_instance(self) -> None:
+        first = self._GetOrCreate("http://192.168.1.5/webcam/?action=stream&t=1")
+        second = self._GetOrCreate("http://192.168.1.5/webcam/?action=stream&t=2")
+        self.assertIs(first, second)
+
+
+    # The QuickCam must connect with the full URL, including the auth token.
+    def test_the_instance_url_keeps_the_token(self) -> None:
+        url = "http://192.168.1.5/webcam/?action=stream&token=abc123&t=1"
+        qc = self._GetOrCreate(url)
+        self.assertEqual(qc.Url, "http://192.168.1.5/webcam/?action=stream&token=abc123")
+
+
+    def test_different_tokens_do_not_share_an_instance(self) -> None:
+        first = self._GetOrCreate("http://192.168.1.5/webcam/?action=stream&token=abc")
+        second = self._GetOrCreate("http://192.168.1.5/webcam/?action=stream&token=xyz")
+        self.assertIsNot(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A webcam URL like `/webcam/?action=stream&token=…` worked in 5.0.2 but returns a 401 since 5.1.0.
QuickCam now handles these URLs, and it only keeps a short allowlist of query params when it normalizes them, so the auth token never reaches the server.

This widens that allowlist to cover the auth and stream selection params servers actually rely on, and moves it into a documented const. Cache-busting params are still stripped, so streams are still shared between viewers as before.

Fixes #160 