### PR TITLE
Elegoo CC2: register relay webcam stream detector (fixes webcam streaming in OctoApp)

### DIFF
--- a/elegoo_cc2_octoeverywhere/elegoocc2host.py
+++ b/elegoo_cc2_octoeverywhere/elegoocc2host.py
@@ -23,6 +23,8 @@ from octoeverywhere.octohttprequest import OctoHttpRequest
 from octoeverywhere.Proto.ServerHost import ServerHost
 from octoeverywhere.sentry import Sentry
 
+from elegoo_octoeverywhere.elegoorelaywebcamurldetector import ElegooRelayWebcamUrlDetector
+
 from .elegoocc2client import ElegooCc2Client
 from .elegoocc2commandhandler import ElegooCc2CommandHandler
 from .elegoocc2filemanager import ElegooCc2FileManager
@@ -89,6 +91,10 @@ class ElegooCc2Host(IHostCommandHandler, IPopUpInvoker, IStateChangeHandler):
 
             webcamHelper = ElegooCc2WebcamHelper(self.Logger, self.Config)
             WebcamHelper.Init(self.Logger, webcamHelper, localStorageDir)
+            # Setup the stream detector that will modify incoming relay requests if needed.
+            # Same as the CC1 host: Elegoo apps (e.g. OctoApp) request the webcam at "/video",
+            # which must be rewritten to a webcam stream request instead of being relayed.
+            Compat.SetRelayWebcamStreamDetector(ElegooRelayWebcamUrlDetector(self.Logger))
 
             stateTranslator = ElegooCc2StateTranslator(self.Logger)
             self.NotificationHandler = NotificationsHandler(self.Logger, stateTranslator)


### PR DESCRIPTION
## Problem

In `elegoo_cc2` companion mode, Elegoo apps such as **OctoApp** request the webcam stream at the path `/video` (the path used by the Elegoo frontend).

The CC1 host handles this via `ElegooRelayWebcamUrlDetector`, which rewrites incoming relay requests containing `/video` into webcam stream requests (registered in `elegoohost.py`). The CC2 host never registers a detector, so `/video` requests fall through and are relayed to the printer as plain HTTP requests. On CC2 stock firmware no such endpoint exists, so the request fails and **OctoApp shows no webcam video**.

Plugin logs show the failure on every attempt:

```
Web Stream http [235] failed to make http request. octoHttpResult was None; url:/video
```

## Fix

Register `ElegooRelayWebcamUrlDetector` in `elegoocc2host.py`, right after `WebcamHelper.Init(...)`, mirroring the CC1 host. Three lines, no other changes.

## Testing

Tested on a real **Elegoo Centauri Carbon 2** (stock firmware, LAN-only mode, companion running in Docker with `COMPANION_MODE=elegoo_cc2`):

- Before: every `/video` request from OctoApp failed with the log line above.
- After: requests are detected and rewritten:

```
ElegooRelayWebcamStreamDetector: Detected webcam stream request, adding oracle headers. Url: /video
Web Stream http [17] STARTING GET type:multipart/x-mixed-replace; boundary=oestreamboundary status:200
```

- Webcam streaming in OctoApp over OctoEverywhere now works, including with a user-configured custom webcam (plugin-local webcam settings with an external MJPEG URL), which was the original goal.